### PR TITLE
Add some DISPLAY pragmas and abstracts

### DIFF
--- a/lib/PropositionalTruncation.agda
+++ b/lib/PropositionalTruncation.agda
@@ -14,9 +14,11 @@ module _ {ℓ₁} where
 
   ∥_∥ : Type ℓ₁ → Type ℓ₁
   ∥_∥ = #∥_∥
+  {-# DISPLAY #∥_∥ = ∥_∥ #-}
 
   ∣_∣ : {X : Type ℓ₁} → X → ∥ X ∥
-  ∣_∣ = #∣_∣ 
+  ∣_∣ = #∣_∣
+  {-# DISPLAY #∣_∣ = ∣_∣ #-}
 
   postulate
     identify : {X : Type ℓ₁} → (x y : ∥ X ∥) → x == y
@@ -35,7 +37,7 @@ module _ {ℓ₁} where
              → ((x : X) → P ∣ x ∣) → ((x : ∥ X ∥) → is-prop (P x))
              → (x : ∥ X ∥) → P x
   indTrunc P f φ #∣ x ∣ = f x
-  
+
   indTrunc' : {ℓ₂ : Level} → {X : Type ℓ₁} → (P : ∥ X ∥ → Type ℓ₂)
               → (f : (x : X) → P ∣ x ∣)
               → (φ : (x y : ∥ X ∥) → {ux : P x} → {uy : P y} → tpt P (identify x y) ux == uy)

--- a/lib/SetTruncation.agda
+++ b/lib/SetTruncation.agda
@@ -32,9 +32,11 @@ module _ {ℓ₁} where
 
   ∥_∥₀ : Type ℓ₁ → Type ℓ₁
   ∥_∥₀ = #∥_∥₀
+  {-# DISPLAY #∥_∥₀ = ∥_∥₀ #-}
 
   ∣_∣₀ : {X : Type ℓ₁} → X → ∥ X ∥₀
-  ∣_∣₀ = #∣_∣₀ 
+  ∣_∣₀ = #∣_∣₀
+  {-# DISPLAY #∣_∣₀ = ∣_∣₀ #-}
 
   postulate
     identify₀ : {X : Type ℓ₁} → {x y : ∥ X ∥₀} → (p q : x == y) → p == q
@@ -48,8 +50,8 @@ module _ {ℓ₁} where
                   → (f : X → Y) → (φ : is-set Y)
                   → {x x' : ∥ X ∥₀} → (p q : x == x')
                   → ap (ap (recTrunc₀ Y f φ)) (identify₀ p q) ==
-                     φ _ _ (ap (recTrunc₀ Y f φ) p) (ap (recTrunc₀ Y f φ) q) 
-  
+                     φ _ _ (ap (recTrunc₀ Y f φ) p) (ap (recTrunc₀ Y f φ) q)
+
   indTrunc₀ : {ℓ₂ : Level} → {X : Type ℓ₁} → (P : ∥ X ∥₀ → Type ℓ₂)
               → ((x : X) → P ∣ x ∣₀) → ((x : ∥ X ∥₀) → is-set (P x))
               → (x : ∥ X ∥₀) → P x

--- a/lib/Univalence.agda
+++ b/lib/Univalence.agda
@@ -16,21 +16,21 @@ postulate
 
 module _ {ℓ} {X Y : Type ℓ} where
 
-  ua : X ≃ Y → X == Y
-  ua = p₁ (univalence X Y)
+  abstract
+    ua : X ≃ Y → X == Y
+    ua = p₁ (univalence X Y)
 
-  -- ua-e is path-to-eqv
-  -- ua-e₁ is (tpt id)
+    -- ua-e is path-to-eqv
+    -- ua-e₁ is (tpt id)
   
-  ua-β : path-to-eqv ∘ ua ∼ id
-  ua-β = p₁ (p₂ (p₂ (univalence X Y)))
+    ua-β : path-to-eqv ∘ ua ∼ id
+    ua-β = p₁ (p₂ (p₂ (univalence X Y)))
 
-  ua-β₁ : tpt id ∘ ua ∼ p₁
-  ua-β₁ = dpair=-e₁ ∘ ua-β
+    ua-β₁ : tpt id ∘ ua ∼ p₁
+    ua-β₁ = dpair=-e₁ ∘ ua-β
 
-  ua-η : ua ∘ path-to-eqv ∼ id
-  ua-η = p₁ (p₂ (univalence X Y))
-
+    ua-η : ua ∘ path-to-eqv ∼ id
+    ua-η = p₁ (p₂ (univalence X Y))
 
 ua-ide : {ℓ : Level} → (X : Type ℓ) → ua (ide X) == refl X
 ua-ide X = ua-η (refl X)


### PR DESCRIPTION
This makes it slightly nicer when doing `C-u C-u C-c C-n` inside a goal. I also want to display tpt as tpt and not coe/ap, but making it abstract breaks lots of things. /cc @ssomayyajula 